### PR TITLE
Bug Fix: Custom column name fails to generate UIDs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,5 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
-.ruby-version
-.ruby-gemset
+.ruby-version*
+.ruby-gemset*

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.rbc
 .bundle
 .config
+.idea
 .yardoc
 Gemfile.lock
 InstalledFiles

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ class User < ActiveRecord::Base
   end
   
   def to_param
-    "#{public_uid}-#{tile.gsub(/\s/,'-'}"
+    "#{public_uid}-#{tile.gsub(/\s/,'-')}"
   end
 end
  

--- a/lib/public_uid/set_public_uid.rb
+++ b/lib/public_uid/set_public_uid.rb
@@ -27,7 +27,7 @@ module PublicUid
     private
 
     def similar_uid_exist?
-      @klass.where(public_uid: new_uid).count > 0
+      @klass.where(@column => new_uid).count > 0
     end
 
     def check_column_existance

--- a/lib/public_uid/tasks/generate.rake
+++ b/lib/public_uid/tasks/generate.rake
@@ -1,3 +1,5 @@
+require 'rake'
+
 namespace :public_uid do
   desc "Generate public_uid on Models that have public_uid column on records that have nil public_uid"
   task :generate => :environment do

--- a/lib/public_uid/tasks/generate.rake
+++ b/lib/public_uid/tasks/generate.rake
@@ -1,22 +1,21 @@
 require 'rake'
 
 namespace :public_uid do
-  desc "Generate public_uid on Models that have public_uid column on records that have nil public_uid"
+  desc "Generate public_uid on Models that have public_uid column on records that have nil value"
   task :generate => :environment do
-    Rails.application.eager_load!
     ActiveRecord::Base.descendants.each do |model|
-      model.connection # establis conection
+      model.connection # establish conection
 
       if model.instance_methods.collect(&:to_s).include?('generate_uid')
-        puts "Model #{model.name}: generating public_uids for missing records"
-
+        puts "Model #{model.name}:"
+        uid_column_name = model.public_uid_column
         model
-          .where(public_uid: nil)
-          .tap { |scope| puts "  * generating #{scope.count} public_uid(s)" }
-          .each do |record_without_public_uid|
-            record_without_public_uid.generate_uid
-            record_without_public_uid.save!
-          end
+          .where(uid_column_name => nil)
+          .tap { |scope| puts "  * generating #{scope.count} #{uid_column_name}(s) for #{model.table_name}" }
+          .find_each do |record_without_public_uid|
+          record_without_public_uid.generate_uid
+          record_without_public_uid.save!
+        end
         puts ''
       end
     end

--- a/lib/public_uid/version.rb
+++ b/lib/public_uid/version.rb
@@ -1,3 +1,3 @@
 module PublicUid
-  VERSION = "1.2.1"
+  VERSION = "1.2.2"
 end

--- a/public_uid.gemspec
+++ b/public_uid.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest", "~> 5"
   spec.add_development_dependency "rr", "~> 1.1.2"
   spec.add_development_dependency "sqlite3"
-  spec.add_development_dependency "activerecord", '~> 3.2'
+  spec.add_development_dependency "activerecord", '~> 4.2' # ensures compatibility for ruby 2.0.0+ to head
 end

--- a/test/lib/set_public_uid_test.rb
+++ b/test/lib/set_public_uid_test.rb
@@ -21,7 +21,7 @@ TestConf.orm_modules.each do |orm_module|
       let(:options)  { {record: record, column: :public_uid} }
       let(:instance) { PublicUid::SetPublicUid.new options }
       let(:record)   { record_class.new }
-      let(:record_class) { "#{orm_module}::User".constantize }
+      let(:record_class) { "#{orm_module}::ModelWithGeneratorDefaults".constantize }
 
       describe 'initialization' do
         context 'when column not specified' do

--- a/test/lib/tasks/generate_test.rb
+++ b/test/lib/tasks/generate_test.rb
@@ -1,0 +1,51 @@
+require 'test_helper'
+require 'rake'
+
+describe 'Generate' do
+  before :all do
+    # load File.expand_path('../../../../lib/public_uid/tasks/generate.rake', __FILE__)
+    Rake.application.rake_require 'public_uid/tasks/generate'
+    Rake::Task.define_task(:environment)
+  end
+
+  TestConf.orm_modules.each do |orm_module|
+    describe orm_module.description do
+      {
+        "#{orm_module}::ModelWithGeneratorDefaults".constantize => :public_uid,
+        "#{orm_module}::ModelWithCustomGererator".constantize   => :public_uid,
+        "#{orm_module}::CustomPublicUidColumnModel".constantize => :custom_uid,
+      }.each_pair do |model, uid_column|
+
+        context "For #{model.name} with #{uid_column}" do
+          let(:run_generate_task) do
+            Rake::Task['public_uid:generate'].reenable
+            Rake.application.invoke_task 'public_uid:generate'
+          end
+
+          describe '#invoke' do
+            it 'generates uid' do
+              user = model.new
+              user.save!
+              initial_uid = user.send(uid_column)
+
+              # simulate an existing record with no uid value
+              user.update_attribute(uid_column, nil).must_equal true
+              user.send(uid_column).must_be_nil
+
+              # run the rake task
+              run_generate_task
+
+              user.reload
+              user.send(uid_column).must_be_kind_of String
+              user.send(uid_column).wont_be_empty
+              user.send(uid_column).wont_be_same_as initial_uid
+            end
+          end
+        end
+
+      end
+
+    end
+  end
+
+end

--- a/test/models/custom_public_uid_column_test.rb
+++ b/test/models/custom_public_uid_column_test.rb
@@ -10,6 +10,14 @@ TestConf.orm_modules.each do |orm_module|
 
         context 'in new record' do
           it{ subject.must_be_nil }
+
+          describe '#generate_uid' do
+            before do
+              user.generate_uid
+            end
+
+            it { subject.wont_be_nil }
+          end
         end
 
         context 'after save' do

--- a/test/models/model_with_custom_generator_test.rb
+++ b/test/models/model_with_custom_generator_test.rb
@@ -10,6 +10,14 @@ TestConf.orm_modules.each do |orm_module|
 
         context 'in new record' do
           it{ subject.must_be_nil }
+
+          describe '#generate_uid' do
+            before do
+              user.generate_uid
+            end
+
+            it { subject.wont_be_nil }
+          end
         end
 
         context 'after save' do

--- a/test/models/model_with_generator_defaults_test.rb
+++ b/test/models/model_with_generator_defaults_test.rb
@@ -10,6 +10,14 @@ TestConf.orm_modules.each do |orm_module|
 
         context 'in new record' do
           it{ subject.must_be_nil }
+
+          describe '#generate_uid' do
+            before do
+              user.generate_uid
+            end
+
+            it { subject.wont_be_nil }
+          end
         end
 
         context 'after save' do

--- a/test/support/orm/active_record.rb
+++ b/test/support/orm/active_record.rb
@@ -1,5 +1,9 @@
 ActiveRecord::Base::establish_connection(adapter: 'sqlite3', database: ':memory:')
-ActiveRecord::Base.connection.execute(%{CREATE TABLE users  (id INTEGER PRIMARY KEY, public_uid VARCHAR, custom_uid VARCHAR);})
+# creates 3 `users` tables, with either `public_uid` or `custom_uid` (but not both), or no uid column,
+# to expose potential `SQLite3::SQLException: no such column` error.
+ActiveRecord::Base.connection.execute(%{CREATE TABLE users (id INTEGER PRIMARY KEY);})
+ActiveRecord::Base.connection.execute(%{CREATE TABLE user_puids (id INTEGER PRIMARY KEY, public_uid VARCHAR);})
+ActiveRecord::Base.connection.execute(%{CREATE TABLE user_cuids (id INTEGER PRIMARY KEY, custom_uid VARCHAR);})
 
 module ActRec
   def self.description
@@ -7,12 +11,12 @@ module ActRec
   end
 
   class CustomPublicUidColumnModel < ActiveRecord::Base
-    self.table_name = "users"
+    self.table_name = 'user_cuids'
     generate_public_uid column: :custom_uid
   end
 
   class ModelWithCustomGererator < ActiveRecord::Base
-    self.table_name = "users"
+    self.table_name = 'user_puids'
 
     gener_range = ('a'..'z').to_a+('A'..'Z').to_a
 
@@ -21,16 +25,12 @@ module ActRec
   end
 
   class ModelWithGeneratorDefaults < ActiveRecord::Base
-    self.table_name =  "users"
+    self.table_name =  'user_puids'
     generate_public_uid
   end
 
   class ModelWithoutGenaratePublicUid < ActiveRecord::Base
-    self.table_name =  "users"
-  end
-
-  class User < ActiveRecord::Base
-    self.table_name = 'users'
+    self.table_name =  'users'
   end
 end
 


### PR DESCRIPTION
The Problem:
----
The custom uid column feature fails to generate uids when used in a real Rails application.


Analysis:
----
- There were hard-coded `public_uid` default column names still exist in the `SetPublicUid` service, as well as the `generate.rake` task.
- Due to the way test DB was set up, a shared `users` table was created with both `public_uid` and `custom_uid`, therefore causing this bug to be disguised.
- There were no tests specifically for `generate_uid` in the model with `custom_uid` column.
- There were no tests for the `generate.rake` task.


Solution:
----
- Test tables are now separated to have 3 scenarios:
  - Without any uid column.
  - With default `public_uid` column.
  - With custom `custom_uid` column.
- This enables real-life tests that will not obfuscate `no such column` or `unknown attribute` type of errors that I've seen in my Rails app.
- Unit tests are added for the model with `custom_uid` column.
- Rake tests are added to simulate the generation of either `public_uid` or `custom_uid` values for existing records that don't have these values.
- Remove redundant test model class that is not used.
- TDD: Without a code fix, 6 tests would fail.
- TDD: After fixing `SetPublicUid` and `generate.rake` task, all tests would pass.
- Minor build version bump.

