### PR TITLE
model.dup should copy model values with nil public_uid

### DIFF
--- a/lib/public_uid/model.rb
+++ b/lib/public_uid/model.rb
@@ -14,6 +14,15 @@ module PublicUid
         pub_uid.generate self.class.public_uid_generator
         pub_uid.set
       end
+
+      def initialize_dup(*)
+        super
+        _clear_public_uid_column
+      end
+
+      def _clear_public_uid_column
+        self.send("#{self.class.public_uid_column}=", nil)
+      end
     end
 
     module ClassMethods

--- a/test/models/custom_public_uid_column_test.rb
+++ b/test/models/custom_public_uid_column_test.rb
@@ -3,7 +3,8 @@ require 'test_helper'
 TestConf.orm_modules.each do |orm_module|
   describe orm_module.description do
     context 'Model with custom public uid column' do
-      let(:user) { "#{orm_module}::CustomPublicUidColumnModel".constantize.new }
+      let(:model_class) { "#{orm_module}::CustomPublicUidColumnModel".constantize }
+      let(:user) { model_class.new }
 
       describe '#custom_uid' do
         subject{ user.custom_uid }
@@ -29,6 +30,26 @@ TestConf.orm_modules.each do |orm_module|
 
           it{ expect(subject).must_be_kind_of(String) }
           it{ expect(subject.length).must_equal(8) }
+        end
+      end
+
+      describe '#dup' do
+        let(:user) { model_class.new(:custom_uid => 'abcdefg') }
+
+        it do
+          dup_user = user.dup
+          expect(user.custom_uid).must_equal('abcdefg')
+          expect(dup_user.custom_uid).must_equal(nil)
+        end
+      end
+
+      describe '#clone' do
+        let(:user) { model_class.new(:custom_uid => 'abcdefg') }
+
+        it do
+          clone_user = user.clone
+          expect(user.custom_uid).must_equal('abcdefg')
+          expect(clone_user.custom_uid).must_equal('abcdefg')
         end
       end
     end

--- a/test/models/model_with_generator_defaults_test.rb
+++ b/test/models/model_with_generator_defaults_test.rb
@@ -3,7 +3,8 @@ require 'test_helper'
 TestConf.orm_modules.each do |orm_module|
   describe orm_module.description do
     context 'Model with default generator' do
-      let(:user) { "#{orm_module}::ModelWithGeneratorDefaults".constantize.new }
+      let(:model_class) { "#{orm_module}::ModelWithGeneratorDefaults".constantize }
+      let(:user) { model_class.new }
 
       describe '#public_uid' do
         subject{ user.public_uid }
@@ -29,6 +30,26 @@ TestConf.orm_modules.each do |orm_module|
 
           it{ expect(subject).must_be_kind_of(String) }
           it{ expect(subject.length).must_equal(8) }
+        end
+      end
+
+      describe '#dup' do
+        let(:user) { model_class.new(:public_uid => 'abcdefg') }
+
+        it do
+          dup_user = user.dup
+          expect(user.public_uid).must_equal('abcdefg')
+          expect(dup_user.public_uid).must_equal(nil)
+        end
+      end
+
+      describe '#clone' do
+        let(:user) { model_class.new(:public_uid => 'abcdefg') }
+
+        it do
+          clone_user = user.clone
+          expect(user.public_uid).must_equal('abcdefg')
+          expect(clone_user.public_uid).must_equal('abcdefg')
         end
       end
     end

--- a/test/models/model_with_public_uid_concern_test.rb
+++ b/test/models/model_with_public_uid_concern_test.rb
@@ -44,6 +44,26 @@ TestConf.orm_modules.each do |orm_module|
           end
         end
       end
+
+      describe '#dup' do
+        let(:user) { model_class.new(:public_uid => 'abcdefg') }
+
+        it do
+          dup_user = user.dup
+          expect(user.public_uid).must_equal('abcdefg')
+          expect(dup_user.public_uid).must_equal(nil)
+        end
+      end
+
+      describe '#clone' do
+        let(:user) { model_class.new(:public_uid => 'abcdefg') }
+
+        it do
+          clone_user = user.clone
+          expect(user.public_uid).must_equal('abcdefg')
+          expect(clone_user.public_uid).must_equal('abcdefg')
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
curent imlplementation:

```
work = Work.last
work.public_uid == 'asdfghjkl'

work_dup = model.dup
work_dup.public_uid == 'asdfghjkl' #this is wrong !!!
```

this should be:

```
work = Work.last
work.public_uid == 'asdfghjkl'

work_dup = model.dup
work_dup.public_uid == nil # this is correct !
```

Why?

read more: https://blog.appsignal.com/2019/02/26/diving-into-dup-and-clone.html
 
important part:

> #dup to allow you to duplicate a record without its "internal" state (id and timestamps), 

Rails implement it same way 

https://github.com/rails/rails/blob/85f45350e6d3fb6284c744d36b77b79ce639dfee/activerecord/lib/active_record/timestamp.rb#L50
